### PR TITLE
Fix typo in AuthZPEClient error string

### DIFF
--- a/clients/nodejs/zpe/src/AuthZPEClient.js
+++ b/clients/nodejs/zpe/src/AuthZPEClient.js
@@ -61,7 +61,7 @@ class AuthZPEClient {
 
         if (!roleToken || !resource || !action) {
             return cb(
-                'ERROR: paramater must include 3 members: roleToken, resource, action',
+                'ERROR: parameter must include 3 members: roleToken, resource, action',
                 AccessCheckStatus.DENY_INVALID_PARAMETERS
             );
         }


### PR DESCRIPTION
## Summary
- correct misspelled `parameter` in allowAccess error message

## Testing
- `npm test` within `clients/nodejs/zpe`

------
https://chatgpt.com/codex/tasks/task_e_6854dc89d4c08321a9fea5eb3e538a42